### PR TITLE
Add DS1307 and DS3232 compatibility info

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,16 @@ I will occasionally test on the following hardware as a sanity check:
 * Teensy 3.2 (72 MHz ARM Cortex-M4)
 * Mini Mega 2560 (Arduino Mega 2560 compatible, 16 MHz ATmega2560)
 
+
+### Untested RTC hardware compatibility
+
+As DS1307 and DS3232 RTC chip have exactly same interface as DS3231 for used
+features except temperature on DS1307 (this one lacks this functionality),
+this class could be be used to control all of them.
+
+Any problem with these RTCs please, contact @Naguissa (https://github.com/Naguissa/AceTime)
+
+
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -2829,3 +2829,12 @@ some time to take a closer look in the future.
       SAMD21 Mini Breakout` board. The `MKR Zero` could be using a different
       (more recent?) version of the GCC tool chain. I have not investigated
       this.
+
+
+## Untested RTC hardware compatibility
+
+As DS1307 and DS3232 RTC chip have exactly same interface as DS3231 for used
+features except temperature on DS1307 (this one lacks this functionality),
+this class could be be used to control all of them.
+
+Any problem with these RTCs please, contact @Naguissa (https://github.com/Naguissa/AceTime)

--- a/src/ace_time/hw/DS3231.h
+++ b/src/ace_time/hw/DS3231.h
@@ -23,6 +23,11 @@ class HardwareTemperature;
  * meant to provide access to all the features of the DS3231 chip. There are
  * other libraries which are far better for that purpose.
  *
+ * UNTESTED ON REAL HARDWARE: As DS1307 and DS3232 RTC chips have exactly same
+ * interface as DS3231 for used features except temperature on DS1307 (as this
+ * one lacks this functionality), this class can be be used to control all of them.
+ * Any problem with these RTCs please, contact @Naguissa (https://github.com/Naguissa/AceTime)
+ *
  * According to https://learn.adafruit.com/i2c-addresses/the-list, the DS3231
  * is always on I2C address 0x68, so let's hardcode that.
  */


### PR DESCRIPTION
No code has to be changed, used registers (except temperature on DS1307) are in the same indexes and same codification is used.