### PR TITLE
merge 2.2.2 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 * Unreleased
+* 2.2.2 (2023-04-01, TZDB version 2023c)
+    * Upgrade TZDB from 2023b to 2023c.
+        * https://mm.icann.org/pipermail/tz-announce/2023-March/000079.html
+            * "This release's code and data are identical to 2023a.  In other
+              words, this release reverts all changes made in 2023b other than
+              commentary, as that appears to be the best of a bad set of
+              short-notice choices for modeling this week's daylight saving
+              chaos in Lebanon."
+    * AceTime is forced to upgrade to 2023c, because we skipped 2023a and went
+      directly to 2023b, which is being rolled back by 2023c.
 * 2.2.1 (2023-03-24, TZDB version 2023b)
     * Actually regenerate the `zonedb*` files to 2023b.
 * 2.2.0 (2023-03-24, TZDB version 2023b)

--- a/README.md
+++ b/README.md
@@ -795,12 +795,13 @@ These boards should work but I don't test them as often:
 
 **Tier 3: May work, but not supported**
 
-* SAMD21 based boards. SAMD21 based boards are now split into 2 groups:
-    * Those using the new ArduinoCore-API, usually Arduino-branded
-      boards. These are explicitly blacklisted. See below.
-    * Other 3rd party SAMD21 boards using the previous Arduino API.
-      These *may* work but I have not explicitly tested any of them except
-      for the Seeed Studio XIAO M0.
+* Other SAMD21 based boards.
+    * SAMD21 based boards are now split into 2 groups:
+        * Those using the new ArduinoCore-API, usually Arduino-branded
+        boards. These are explicitly blacklisted. See below.
+        * Other 3rd party SAMD21 boards using the previous Arduino API.
+    * The ones using the previous Arduino API *may* work but I have not
+      explicitly tested any of them except for the Seeed Studio XIAO M0.
 
 **Tier Blacklisted**
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This library can be an alternative to the Arduino Time
 offsets of type `kTypeManual`. See [Migrating to
 v2.2.0](MIGRATING.md#MigratingToVersion220) for details.
 
-**Version**: 2.2.1 (2023-03-24, TZDB version 2023b)
+**Version**: 2.2.2 (2023-04-01, TZDB version 2023c)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -18,7 +18,7 @@ valid from the years `[2000,10000)`. By adjusting the `currentEpochYear()`, the
 library will work across any 100 year interval across the 8000 year range of the
 TZ database.
 
-**Version**: 2.2.1 (2023-03-24, TZDB 2023b)
+**Version**: 2.2.2 (2023-04-01, TZDB 2023c)
 
 **Related Documents**:
 

--- a/examples/AutoBenchmark/README.md
+++ b/examples/AutoBenchmark/README.md
@@ -346,7 +346,7 @@ Iterations_per_run: 1000
 
 ```
 
-## Seeed Studio XIOA SAMD21
+## Seeed Studio XIAO SAMD21
 
 * SAMD21, 48 MHz ARM Cortex-M0+
 * Arduino IDE 1.8.19, Arduino CLI 0.31.0

--- a/examples/AutoBenchmark/generate_readme.py
+++ b/examples/AutoBenchmark/generate_readme.py
@@ -230,7 +230,7 @@ The CPU times below are given in microseconds.
 {micro_results}
 ```
 
-## Seeed Studio XIOA SAMD21
+## Seeed Studio XIAO SAMD21
 
 * SAMD21, 48 MHz ARM Cortex-M0+
 * Arduino IDE 1.8.19, Arduino CLI 0.31.0

--- a/examples/MemoryBenchmark/README.md
+++ b/examples/MemoryBenchmark/README.md
@@ -309,7 +309,7 @@ ASCII table.
 
 ```
 
-## Seeed Studio XIAO
+## Seeed Studio XIAO SAMD21
 
 * SAMD21, 48 MHz ARM Cortex-M0+
 * Arduino IDE 1.8.19, Arduino CLI 0.31.1

--- a/examples/MemoryBenchmark/generate_readme.py
+++ b/examples/MemoryBenchmark/generate_readme.py
@@ -279,7 +279,7 @@ ASCII table.
 {micro_results}
 ```
 
-## Seeed Studio XIAO
+## Seeed Studio XIAO SAMD21
 
 * SAMD21, 48 MHz ARM Cortex-M0+
 * Arduino IDE 1.8.19, Arduino CLI 0.31.1

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AceTime
-version=2.2.1
+version=2.2.2
 author=Brian T. Park <brian@xparks.net>
 maintainer=Brian T. Park <brian@xparks.net>
 sentence=Date, time, timezone classes for Arduino supporting the full IANA TZ Database to convert epoch seconds to date and time components in different time zones.

--- a/src/AceTime.h
+++ b/src/AceTime.h
@@ -66,7 +66,7 @@
 #include "zonedbx/zone_registry.h"
 
 // Version format: xxyyzz == "xx.yy.zz"
-#define ACE_TIME_VERSION 20201
-#define ACE_TIME_VERSION_STRING "2.2.1"
+#define ACE_TIME_VERSION 20202
+#define ACE_TIME_VERSION_STRING "2.2.2"
 
 #endif

--- a/src/tzonedb/Makefile
+++ b/src/tzonedb/Makefile
@@ -2,7 +2,7 @@ TARGETS := zone_infos.cpp zone_infos.h zone_policies.cpp zone_policies.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2023b
+TZ_VERSION := 2023c
 START_YEAR := 1980
 UNTIL_YEAR := 10000
 

--- a/src/tzonedb/zone_infos.cpp
+++ b/src/tzonedb/zone_infos.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 12 (11 zones, 1 links)
 // Unsupported Zones: 584 (339 zones, 245 links)
@@ -81,7 +81,7 @@ namespace tzonedb {
 // ZoneContext (should not be in PROGMEM)
 //---------------------------------------------------------------------------
 
-const char kTzDatabaseVersion[] = "2023b";
+const char kTzDatabaseVersion[] = "2023c";
 
 const char* const kFragments[] = {
 /*\x00*/ nullptr,

--- a/src/tzonedb/zone_infos.h
+++ b/src/tzonedb/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 12 (11 zones, 1 links)
 // Unsupported Zones: 584 (339 zones, 245 links)

--- a/src/tzonedb/zone_policies.cpp
+++ b/src/tzonedb/zone_policies.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 12 (11 zones, 1 links)
 // Unsupported Zones: 584 (339 zones, 245 links)

--- a/src/tzonedb/zone_policies.h
+++ b/src/tzonedb/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 12 (11 zones, 1 links)
 // Unsupported Zones: 584 (339 zones, 245 links)

--- a/src/tzonedb/zone_registry.cpp
+++ b/src/tzonedb/zone_registry.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 12 (11 zones, 1 links)
 // Unsupported Zones: 584 (339 zones, 245 links)

--- a/src/tzonedb/zone_registry.h
+++ b/src/tzonedb/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 12 (11 zones, 1 links)
 // Unsupported Zones: 584 (339 zones, 245 links)

--- a/src/tzonedbx/Makefile
+++ b/src/tzonedbx/Makefile
@@ -2,7 +2,7 @@ TARGETS := zone_infos.cpp zone_infos.h zone_policies.cpp zone_policies.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2023b
+TZ_VERSION := 2023c
 START_YEAR := 1980
 UNTIL_YEAR := 10000
 

--- a/src/tzonedbx/zone_infos.cpp
+++ b/src/tzonedbx/zone_infos.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 16 (15 zones, 1 links)
 // Unsupported Zones: 580 (335 zones, 245 links)
@@ -81,7 +81,7 @@ namespace tzonedbx {
 // ZoneContext (should not be in PROGMEM)
 //---------------------------------------------------------------------------
 
-const char kTzDatabaseVersion[] = "2023b";
+const char kTzDatabaseVersion[] = "2023c";
 
 const char* const kFragments[] = {
 /*\x00*/ nullptr,

--- a/src/tzonedbx/zone_infos.h
+++ b/src/tzonedbx/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 16 (15 zones, 1 links)
 // Unsupported Zones: 580 (335 zones, 245 links)

--- a/src/tzonedbx/zone_infos.h
+++ b/src/tzonedbx/zone_infos.h
@@ -512,13 +512,13 @@ const uint8_t kZoneBufSizePacific_Apia = 5;  // Pacific/Apia in 2011
 //---------------------------------------------------------------------------
 
 // Africa/Casablanca {
-//   Morocco {SAVE '-1:00' different from 1:00}
+//   Morocco {SAVE '-1:00' is a negative DST}
 // }
 // Africa/Windhoek {
 //   Namibia {
 //     LETTER 'CAT' not single character,
 //     LETTER 'WAT' not single character,
-//     SAVE '-1:00' different from 1:00,
+//     SAVE '-1:00' is a negative DST,
 //   }
 // }
 

--- a/src/tzonedbx/zone_policies.cpp
+++ b/src/tzonedbx/zone_policies.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 16 (15 zones, 1 links)
 // Unsupported Zones: 580 (335 zones, 245 links)

--- a/src/tzonedbx/zone_policies.h
+++ b/src/tzonedbx/zone_policies.h
@@ -229,11 +229,11 @@ extern const extended::ZonePolicy kZonePolicyWinn;
 // Notable zone policies: 2
 //---------------------------------------------------------------------------
 
-// Morocco {SAVE '-1:00' different from 1:00}
+// Morocco {SAVE '-1:00' is a negative DST}
 // Namibia {
 //   LETTER 'CAT' not single character,
 //   LETTER 'WAT' not single character,
-//   SAVE '-1:00' different from 1:00,
+//   SAVE '-1:00' is a negative DST,
 // }
 
 

--- a/src/tzonedbx/zone_policies.h
+++ b/src/tzonedbx/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 16 (15 zones, 1 links)
 // Unsupported Zones: 580 (335 zones, 245 links)

--- a/src/tzonedbx/zone_registry.cpp
+++ b/src/tzonedbx/zone_registry.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 16 (15 zones, 1 links)
 // Unsupported Zones: 580 (335 zones, 245 links)

--- a/src/tzonedbx/zone_registry.h
+++ b/src/tzonedbx/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/tzonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/tzonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -26,7 +26,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 16 (15 zones, 1 links)
 // Unsupported Zones: 580 (335 zones, 245 links)

--- a/src/zonedb/Makefile
+++ b/src/zonedb/Makefile
@@ -2,7 +2,7 @@ TARGETS := zone_infos.cpp zone_infos.h zone_policies.cpp zone_policies.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2023b
+TZ_VERSION := 2023c
 START_YEAR := 2000
 UNTIL_YEAR := 10000
 

--- a/src/zonedb/zone_infos.cpp
+++ b/src/zonedb/zone_infos.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -23,24 +23,24 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 446 (226 zones, 220 links)
 // Unsupported Zones: 150 (124 zones, 26 links)
 //
 // Original Years:  [1844,2087]
-// Generated Years: [1950,2024]
-// Estimator Years: [1950,2026]
+// Generated Years: [1950,2023]
+// Estimator Years: [1950,2025]
 // Max Buffer Size: 6
 //
 // Records:
 //   Infos: 446
 //   Eras: 238
 //   Policies: 63
-//   Rules: 364
+//   Rules: 362
 //
 // Memory (8-bits):
-//   Rules: 4004
+//   Rules: 3982
 //   Policies: 189
 //   Eras: 2856
 //   Zones: 2938
@@ -50,10 +50,10 @@
 //   Letters: 11
 //   Fragments: 116
 //   Names: 4144 (original: 6503)
-//   TOTAL: 18475
+//   TOTAL: 18453
 //
 // Memory (32-bits):
-//   Rules: 4368
+//   Rules: 4344
 //   Policies: 504
 //   Eras: 3808
 //   Zones: 5424
@@ -63,7 +63,7 @@
 //   Letters: 17
 //   Fragments: 138
 //   Names: 4144 (original: 6503)
-//   TOTAL: 25932
+//   TOTAL: 25908
 //
 // DO NOT EDIT
 
@@ -78,7 +78,7 @@ namespace zonedb {
 // ZoneContext (should not be in PROGMEM)
 //---------------------------------------------------------------------------
 
-const char kTzDatabaseVersion[] = "2023b";
+const char kTzDatabaseVersion[] = "2023c";
 
 const char* const kFragments[] = {
 /*\x00*/ nullptr,

--- a/src/zonedb/zone_infos.h
+++ b/src/zonedb/zone_infos.h
@@ -1302,7 +1302,7 @@ const uint8_t kZoneBufSizeWET = 5;  // WET in 1983
 // America/Whitehorse {UNTIL contains month/day/time}
 // Antarctica/Casey {UNTIL contains month/day/time}
 // Antarctica/Davis {UNTIL contains month/day/time}
-// Antarctica/Macquarie {unsupported fixed RULES offset '1:00'}
+// Antarctica/Macquarie {unsupported fixed RULES '1:00'}
 // Antarctica/Mawson {UNTIL contains month/day/time}
 // Antarctica/Palmer {UNTIL contains month/day/time}
 // Antarctica/Troll {UNTIL contains month/day/time}
@@ -1370,17 +1370,17 @@ const uint8_t kZoneBufSizeWET = 5;  // WET in 1983
 
 // Africa/Johannesburg {RULES not fixed but FORMAT is missing '%' or '/'}
 // America/Moncton {
-//   Moncton {AT '0:01' not on 15-minute boundary}
+//   Moncton {AT '0:01' not multiple of :15 min}
 // }
-// Asia/Kathmandu {STDOFF '5:45' not at :00 or :30 mark}
-// Australia/Eucla {STDOFF '8:45' not at :00 or :30 mark}
+// Asia/Kathmandu {STDOFF '5:45' not multiple of :30 min}
+// Australia/Eucla {STDOFF '8:45' not multiple of :30 min}
 // Australia/Lord_Howe {
 //   LH {SAVE '0:30' different from 1:00}
 // }
 // Europe/Dublin {
-//   Eire {SAVE '-1:00' different from 1:00}
+//   Eire {SAVE '-1:00' is a negative DST}
 // }
-// Pacific/Chatham {STDOFF '12:45' not at :00 or :30 mark}
+// Pacific/Chatham {STDOFF '12:45' not multiple of :30 min}
 
 
 //---------------------------------------------------------------------------

--- a/src/zonedb/zone_infos.h
+++ b/src/zonedb/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -23,24 +23,24 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 446 (226 zones, 220 links)
 // Unsupported Zones: 150 (124 zones, 26 links)
 //
 // Original Years:  [1844,2087]
-// Generated Years: [1950,2024]
-// Estimator Years: [1950,2026]
+// Generated Years: [1950,2023]
+// Estimator Years: [1950,2025]
 // Max Buffer Size: 6
 //
 // Records:
 //   Infos: 446
 //   Eras: 238
 //   Policies: 63
-//   Rules: 364
+//   Rules: 362
 //
 // Memory (8-bits):
-//   Rules: 4004
+//   Rules: 3982
 //   Policies: 189
 //   Eras: 2856
 //   Zones: 2938
@@ -50,10 +50,10 @@
 //   Letters: 11
 //   Fragments: 116
 //   Names: 4144 (original: 6503)
-//   TOTAL: 18475
+//   TOTAL: 18453
 //
 // Memory (32-bits):
-//   Rules: 4368
+//   Rules: 4344
 //   Policies: 504
 //   Eras: 3808
 //   Zones: 5424
@@ -63,7 +63,7 @@
 //   Letters: 17
 //   Fragments: 138
 //   Names: 4144 (original: 6503)
-//   TOTAL: 25932
+//   TOTAL: 25908
 //
 // DO NOT EDIT
 

--- a/src/zonedb/zone_policies.cpp
+++ b/src/zonedb/zone_policies.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -23,24 +23,24 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 446 (226 zones, 220 links)
 // Unsupported Zones: 150 (124 zones, 26 links)
 //
 // Original Years:  [1844,2087]
-// Generated Years: [1950,2024]
-// Estimator Years: [1950,2026]
+// Generated Years: [1950,2023]
+// Estimator Years: [1950,2025]
 // Max Buffer Size: 6
 //
 // Records:
 //   Infos: 446
 //   Eras: 238
 //   Policies: 63
-//   Rules: 364
+//   Rules: 362
 //
 // Memory (8-bits):
-//   Rules: 4004
+//   Rules: 3982
 //   Policies: 189
 //   Eras: 2856
 //   Zones: 2938
@@ -50,10 +50,10 @@
 //   Letters: 11
 //   Fragments: 116
 //   Names: 4144 (original: 6503)
-//   TOTAL: 18475
+//   TOTAL: 18453
 //
 // Memory (32-bits):
-//   Rules: 4368
+//   Rules: 4344
 //   Policies: 504
 //   Eras: 3808
 //   Zones: 5424
@@ -63,7 +63,7 @@
 //   Letters: 17
 //   Fragments: 138
 //   Names: 4144 (original: 6503)
-//   TOTAL: 25932
+//   TOTAL: 25908
 //
 // DO NOT EDIT
 
@@ -75,7 +75,7 @@ namespace zonedb {
 
 //---------------------------------------------------------------------------
 // Policies: 63
-// Rules: 364
+// Rules: 362
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -3306,7 +3306,7 @@ const basic::ZonePolicy kZonePolicyLH ACE_TIME_PROGMEM = {
 
 //---------------------------------------------------------------------------
 // Policy name: Lebanon
-// Rules: 6
+// Rules: 4
 //---------------------------------------------------------------------------
 
 static const basic::ZoneRule kZoneRulesLebanon[] ACE_TIME_PROGMEM = {
@@ -3322,10 +3322,10 @@ static const basic::ZoneRule kZoneRulesLebanon[] ACE_TIME_PROGMEM = {
     4 /*deltaCode ((deltaMinutes=0)/15 + 4)*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule    Lebanon    1993    2022    -    Mar    lastSun    0:00    1:00    S
+  // Rule    Lebanon    1993    max    -    Mar    lastSun    0:00    1:00    S
   {
     1993 /*fromYear*/,
-    2022 /*toYear*/,
+    32766 /*toYear*/,
     3 /*inMonth*/,
     7 /*onDayOfWeek*/,
     0 /*onDayOfMonth*/,
@@ -3358,36 +3358,12 @@ static const basic::ZoneRule kZoneRulesLebanon[] ACE_TIME_PROGMEM = {
     4 /*deltaCode ((deltaMinutes=0)/15 + 4)*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule    Lebanon    2023    only    -    Apr    21    0:00    1:00    S
-  {
-    2023 /*fromYear*/,
-    2023 /*toYear*/,
-    4 /*inMonth*/,
-    0 /*onDayOfWeek*/,
-    21 /*onDayOfMonth*/,
-    0 /*atTimeCode*/,
-    0 /*atTimeModifier (kSuffixW + minute=0)*/,
-    8 /*deltaCode ((deltaMinutes=60)/15 + 4)*/,
-    2 /*letterIndex ("S")*/,
-  },
-  // Rule    Lebanon    2024    max    -    Mar    lastSun    0:00    1:00    S
-  {
-    2024 /*fromYear*/,
-    32766 /*toYear*/,
-    3 /*inMonth*/,
-    7 /*onDayOfWeek*/,
-    0 /*onDayOfMonth*/,
-    0 /*atTimeCode*/,
-    0 /*atTimeModifier (kSuffixW + minute=0)*/,
-    8 /*deltaCode ((deltaMinutes=60)/15 + 4)*/,
-    2 /*letterIndex ("S")*/,
-  },
 
 };
 
 const basic::ZonePolicy kZonePolicyLebanon ACE_TIME_PROGMEM = {
   kZoneRulesLebanon /*rules*/,
-  6 /*numRules*/,
+  4 /*numRules*/,
 };
 
 //---------------------------------------------------------------------------

--- a/src/zonedb/zone_policies.h
+++ b/src/zonedb/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -23,24 +23,24 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 446 (226 zones, 220 links)
 // Unsupported Zones: 150 (124 zones, 26 links)
 //
 // Original Years:  [1844,2087]
-// Generated Years: [1950,2024]
-// Estimator Years: [1950,2026]
+// Generated Years: [1950,2023]
+// Estimator Years: [1950,2025]
 // Max Buffer Size: 6
 //
 // Records:
 //   Infos: 446
 //   Eras: 238
 //   Policies: 63
-//   Rules: 364
+//   Rules: 362
 //
 // Memory (8-bits):
-//   Rules: 4004
+//   Rules: 3982
 //   Policies: 189
 //   Eras: 2856
 //   Zones: 2938
@@ -50,10 +50,10 @@
 //   Letters: 11
 //   Fragments: 116
 //   Names: 4144 (original: 6503)
-//   TOTAL: 18475
+//   TOTAL: 18453
 //
 // Memory (32-bits):
-//   Rules: 4368
+//   Rules: 4344
 //   Policies: 504
 //   Eras: 3808
 //   Zones: 5424
@@ -63,7 +63,7 @@
 //   Letters: 17
 //   Fragments: 138
 //   Names: 4144 (original: 6503)
-//   TOTAL: 25932
+//   TOTAL: 25908
 //
 // DO NOT EDIT
 
@@ -77,7 +77,7 @@ namespace zonedb {
 
 //---------------------------------------------------------------------------
 // Supported policies: 63
-// Supported rules: 364
+// Supported rules: 362
 //---------------------------------------------------------------------------
 
 extern const basic::ZonePolicy kZonePolicyAN;

--- a/src/zonedb/zone_policies.h
+++ b/src/zonedb/zone_policies.h
@@ -223,13 +223,18 @@ extern const basic::ZonePolicy kZonePolicyZion;
 
 
 //---------------------------------------------------------------------------
-// Notable zone policies: 4
+// Notable zone policies: 5
 //---------------------------------------------------------------------------
 
-// Eire {SAVE '-1:00' different from 1:00}
+// Belize {LETTER 'CST' not single character}
+// Eire {SAVE '-1:00' is a negative DST}
 // LH {SAVE '0:30' different from 1:00}
-// Moncton {AT '0:01' not on 15-minute boundary}
-// Namibia {SAVE '-1:00' different from 1:00}
+// Moncton {AT '0:01' not multiple of :15 min}
+// Namibia {
+//   LETTER 'CAT' not single character,
+//   LETTER 'WAT' not single character,
+//   SAVE '-1:00' is a negative DST,
+// }
 
 
 }

--- a/src/zonedb/zone_registry.cpp
+++ b/src/zonedb/zone_registry.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -23,24 +23,24 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 446 (226 zones, 220 links)
 // Unsupported Zones: 150 (124 zones, 26 links)
 //
 // Original Years:  [1844,2087]
-// Generated Years: [1950,2024]
-// Estimator Years: [1950,2026]
+// Generated Years: [1950,2023]
+// Estimator Years: [1950,2025]
 // Max Buffer Size: 6
 //
 // Records:
 //   Infos: 446
 //   Eras: 238
 //   Policies: 63
-//   Rules: 364
+//   Rules: 362
 //
 // Memory (8-bits):
-//   Rules: 4004
+//   Rules: 3982
 //   Policies: 189
 //   Eras: 2856
 //   Zones: 2938
@@ -50,10 +50,10 @@
 //   Letters: 11
 //   Fragments: 116
 //   Names: 4144 (original: 6503)
-//   TOTAL: 18475
+//   TOTAL: 18453
 //
 // Memory (32-bits):
-//   Rules: 4368
+//   Rules: 4344
 //   Policies: 504
 //   Eras: 3808
 //   Zones: 5424
@@ -63,7 +63,7 @@
 //   Letters: 17
 //   Fragments: 138
 //   Names: 4144 (original: 6503)
-//   TOTAL: 25932
+//   TOTAL: 25908
 //
 // DO NOT EDIT
 

--- a/src/zonedb/zone_registry.h
+++ b/src/zonedb/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedb/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedb
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope basic
@@ -23,24 +23,24 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 446 (226 zones, 220 links)
 // Unsupported Zones: 150 (124 zones, 26 links)
 //
 // Original Years:  [1844,2087]
-// Generated Years: [1950,2024]
-// Estimator Years: [1950,2026]
+// Generated Years: [1950,2023]
+// Estimator Years: [1950,2025]
 // Max Buffer Size: 6
 //
 // Records:
 //   Infos: 446
 //   Eras: 238
 //   Policies: 63
-//   Rules: 364
+//   Rules: 362
 //
 // Memory (8-bits):
-//   Rules: 4004
+//   Rules: 3982
 //   Policies: 189
 //   Eras: 2856
 //   Zones: 2938
@@ -50,10 +50,10 @@
 //   Letters: 11
 //   Fragments: 116
 //   Names: 4144 (original: 6503)
-//   TOTAL: 18475
+//   TOTAL: 18453
 //
 // Memory (32-bits):
-//   Rules: 4368
+//   Rules: 4344
 //   Policies: 504
 //   Eras: 3808
 //   Zones: 5424
@@ -63,7 +63,7 @@
 //   Letters: 17
 //   Fragments: 138
 //   Names: 4144 (original: 6503)
-//   TOTAL: 25932
+//   TOTAL: 25908
 //
 // DO NOT EDIT
 

--- a/src/zonedbx/Makefile
+++ b/src/zonedbx/Makefile
@@ -2,7 +2,7 @@ TARGETS := zone_infos.cpp zone_infos.h zone_policies.cpp zone_policies.h
 
 TOOLS := $(abspath ../../../AceTimeTools)
 TZ_REPO := $(abspath $(TOOLS)/../tz)
-TZ_VERSION := 2023b
+TZ_VERSION := 2023c
 START_YEAR := 2000
 UNTIL_YEAR := 10000
 

--- a/src/zonedbx/zone_infos.cpp
+++ b/src/zonedbx/zone_infos.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -23,7 +23,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -37,10 +37,10 @@
 //   Infos: 596
 //   Eras: 646
 //   Policies: 83
-//   Rules: 737
+//   Rules: 735
 //
 // Memory (8-bits):
-//   Rules: 8107
+//   Rules: 8085
 //   Policies: 249
 //   Eras: 7752
 //   Zones: 4550
@@ -50,10 +50,10 @@
 //   Letters: 46
 //   Fragments: 150
 //   Names: 5649 (original: 9076)
-//   TOTAL: 31490
+//   TOTAL: 31468
 //
 // Memory (32-bits):
-//   Rules: 8844
+//   Rules: 8820
 //   Policies: 664
 //   Eras: 10336
 //   Zones: 8400
@@ -63,7 +63,7 @@
 //   Letters: 64
 //   Fragments: 178
 //   Names: 5649 (original: 9076)
-//   TOTAL: 43020
+//   TOTAL: 42996
 //
 // DO NOT EDIT
 
@@ -78,7 +78,7 @@ namespace zonedbx {
 // ZoneContext (should not be in PROGMEM)
 //---------------------------------------------------------------------------
 
-const char kTzDatabaseVersion[] = "2023b";
+const char kTzDatabaseVersion[] = "2023c";
 
 const char* const kFragments[] = {
 /*\x00*/ nullptr,

--- a/src/zonedbx/zone_infos.h
+++ b/src/zonedbx/zone_infos.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -23,7 +23,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -37,10 +37,10 @@
 //   Infos: 596
 //   Eras: 646
 //   Policies: 83
-//   Rules: 737
+//   Rules: 735
 //
 // Memory (8-bits):
-//   Rules: 8107
+//   Rules: 8085
 //   Policies: 249
 //   Eras: 7752
 //   Zones: 4550
@@ -50,10 +50,10 @@
 //   Letters: 46
 //   Fragments: 150
 //   Names: 5649 (original: 9076)
-//   TOTAL: 31490
+//   TOTAL: 31468
 //
 // Memory (32-bits):
-//   Rules: 8844
+//   Rules: 8820
 //   Policies: 664
 //   Eras: 10336
 //   Zones: 8400
@@ -63,7 +63,7 @@
 //   Letters: 64
 //   Fragments: 178
 //   Names: 5649 (original: 9076)
-//   TOTAL: 43020
+//   TOTAL: 42996
 //
 // DO NOT EDIT
 

--- a/src/zonedbx/zone_infos.h
+++ b/src/zonedbx/zone_infos.h
@@ -1669,17 +1669,17 @@ const uint8_t kZoneBufSizeWET = 5;  // WET in 1983
 //---------------------------------------------------------------------------
 
 // Africa/Casablanca {
-//   Morocco {SAVE '-1:00' different from 1:00}
+//   Morocco {SAVE '-1:00' is a negative DST}
 // }
 // Africa/El_Aaiun {
-//   Morocco {SAVE '-1:00' different from 1:00}
+//   Morocco {SAVE '-1:00' is a negative DST}
 // }
 // Africa/Johannesburg {RULES not fixed but FORMAT is missing '%' or '/'}
 // Africa/Windhoek {
 //   Namibia {
 //     LETTER 'CAT' not single character,
 //     LETTER 'WAT' not single character,
-//     SAVE '-1:00' different from 1:00,
+//     SAVE '-1:00' is a negative DST,
 //   }
 // }
 // America/Belize {
@@ -1687,22 +1687,22 @@ const uint8_t kZoneBufSizeWET = 5;  // WET in 1983
 // }
 // America/Goose_Bay {
 //   StJohns {
-//     AT '0:01' not on 15-minute boundary,
+//     AT '0:01' not multiple of :15 min,
 //     LETTER 'DD' not single character,
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
 // America/Moncton {
-//   Moncton {AT '0:01' not on 15-minute boundary}
+//   Moncton {AT '0:01' not multiple of :15 min}
 // }
 // America/St_Johns {
 //   StJohns {
-//     AT '0:01' not on 15-minute boundary,
+//     AT '0:01' not multiple of :15 min,
 //     LETTER 'DD' not single character,
 //     SAVE '2:00' different from 1:00,
 //   }
 // }
-// Antarctica/Casey {UNTIL '0:01' not on 15-minute boundary}
+// Antarctica/Casey {UNTIL '0:01' not multiple of :15 min}
 // Antarctica/Troll {
 //   Troll {
 //     LETTER '+00' not single character,
@@ -1711,21 +1711,21 @@ const uint8_t kZoneBufSizeWET = 5;  // WET in 1983
 //   }
 // }
 // Asia/Gaza {
-//   UNTIL '0:01' not on 15-minute boundary,
-//   Palestine {AT '0:01' not on 15-minute boundary}
+//   UNTIL '0:01' not multiple of :15 min,
+//   Palestine {AT '0:01' not multiple of :15 min}
 // }
 // Asia/Hebron {
-//   Palestine {AT '0:01' not on 15-minute boundary}
+//   Palestine {AT '0:01' not multiple of :15 min}
 // }
-// Asia/Kathmandu {STDOFF '5:45' not at :00 or :30 mark}
-// Australia/Eucla {STDOFF '8:45' not at :00 or :30 mark}
+// Asia/Kathmandu {STDOFF '5:45' not multiple of :30 min}
+// Australia/Eucla {STDOFF '8:45' not multiple of :30 min}
 // Australia/Lord_Howe {
 //   LH {SAVE '0:30' different from 1:00}
 // }
 // Europe/Dublin {
-//   Eire {SAVE '-1:00' different from 1:00}
+//   Eire {SAVE '-1:00' is a negative DST}
 // }
-// Pacific/Chatham {STDOFF '12:45' not at :00 or :30 mark}
+// Pacific/Chatham {STDOFF '12:45' not multiple of :30 min}
 
 
 //---------------------------------------------------------------------------

--- a/src/zonedbx/zone_policies.cpp
+++ b/src/zonedbx/zone_policies.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -23,7 +23,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -37,10 +37,10 @@
 //   Infos: 596
 //   Eras: 646
 //   Policies: 83
-//   Rules: 737
+//   Rules: 735
 //
 // Memory (8-bits):
-//   Rules: 8107
+//   Rules: 8085
 //   Policies: 249
 //   Eras: 7752
 //   Zones: 4550
@@ -50,10 +50,10 @@
 //   Letters: 46
 //   Fragments: 150
 //   Names: 5649 (original: 9076)
-//   TOTAL: 31490
+//   TOTAL: 31468
 //
 // Memory (32-bits):
-//   Rules: 8844
+//   Rules: 8820
 //   Policies: 664
 //   Eras: 10336
 //   Zones: 8400
@@ -63,7 +63,7 @@
 //   Letters: 64
 //   Fragments: 178
 //   Names: 5649 (original: 9076)
-//   TOTAL: 43020
+//   TOTAL: 42996
 //
 // DO NOT EDIT
 
@@ -75,7 +75,7 @@ namespace zonedbx {
 
 //---------------------------------------------------------------------------
 // Policies: 83
-// Rules: 737
+// Rules: 735
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
@@ -3884,7 +3884,7 @@ const extended::ZonePolicy kZonePolicyLH ACE_TIME_PROGMEM = {
 
 //---------------------------------------------------------------------------
 // Policy name: Lebanon
-// Rules: 6
+// Rules: 4
 //---------------------------------------------------------------------------
 
 static const extended::ZoneRule kZoneRulesLebanon[] ACE_TIME_PROGMEM = {
@@ -3900,10 +3900,10 @@ static const extended::ZoneRule kZoneRulesLebanon[] ACE_TIME_PROGMEM = {
     4 /*deltaCode ((deltaMinutes=0)/15 + 4)*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule    Lebanon    1993    2022    -    Mar    lastSun    0:00    1:00    S
+  // Rule    Lebanon    1993    max    -    Mar    lastSun    0:00    1:00    S
   {
     1993 /*fromYear*/,
-    2022 /*toYear*/,
+    32766 /*toYear*/,
     3 /*inMonth*/,
     7 /*onDayOfWeek*/,
     0 /*onDayOfMonth*/,
@@ -3936,36 +3936,12 @@ static const extended::ZoneRule kZoneRulesLebanon[] ACE_TIME_PROGMEM = {
     4 /*deltaCode ((deltaMinutes=0)/15 + 4)*/,
     0 /*letterIndex ("")*/,
   },
-  // Rule    Lebanon    2023    only    -    Apr    21    0:00    1:00    S
-  {
-    2023 /*fromYear*/,
-    2023 /*toYear*/,
-    4 /*inMonth*/,
-    0 /*onDayOfWeek*/,
-    21 /*onDayOfMonth*/,
-    0 /*atTimeCode*/,
-    0 /*atTimeModifier (kSuffixW + minute=0)*/,
-    8 /*deltaCode ((deltaMinutes=60)/15 + 4)*/,
-    7 /*letterIndex ("S")*/,
-  },
-  // Rule    Lebanon    2024    max    -    Mar    lastSun    0:00    1:00    S
-  {
-    2024 /*fromYear*/,
-    32766 /*toYear*/,
-    3 /*inMonth*/,
-    7 /*onDayOfWeek*/,
-    0 /*onDayOfMonth*/,
-    0 /*atTimeCode*/,
-    0 /*atTimeModifier (kSuffixW + minute=0)*/,
-    8 /*deltaCode ((deltaMinutes=60)/15 + 4)*/,
-    7 /*letterIndex ("S")*/,
-  },
 
 };
 
 const extended::ZonePolicy kZonePolicyLebanon ACE_TIME_PROGMEM = {
   kZoneRulesLebanon /*rules*/,
-  6 /*numRules*/,
+  4 /*numRules*/,
 };
 
 //---------------------------------------------------------------------------

--- a/src/zonedbx/zone_policies.h
+++ b/src/zonedbx/zone_policies.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -23,7 +23,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -37,10 +37,10 @@
 //   Infos: 596
 //   Eras: 646
 //   Policies: 83
-//   Rules: 737
+//   Rules: 735
 //
 // Memory (8-bits):
-//   Rules: 8107
+//   Rules: 8085
 //   Policies: 249
 //   Eras: 7752
 //   Zones: 4550
@@ -50,10 +50,10 @@
 //   Letters: 46
 //   Fragments: 150
 //   Names: 5649 (original: 9076)
-//   TOTAL: 31490
+//   TOTAL: 31468
 //
 // Memory (32-bits):
-//   Rules: 8844
+//   Rules: 8820
 //   Policies: 664
 //   Eras: 10336
 //   Zones: 8400
@@ -63,7 +63,7 @@
 //   Letters: 64
 //   Fragments: 178
 //   Names: 5649 (original: 9076)
-//   TOTAL: 43020
+//   TOTAL: 42996
 //
 // DO NOT EDIT
 
@@ -77,7 +77,7 @@ namespace zonedbx {
 
 //---------------------------------------------------------------------------
 // Supported policies: 83
-// Supported rules: 737
+// Supported rules: 735
 //---------------------------------------------------------------------------
 
 extern const extended::ZonePolicy kZonePolicyAN;

--- a/src/zonedbx/zone_policies.h
+++ b/src/zonedbx/zone_policies.h
@@ -227,18 +227,18 @@ extern const extended::ZonePolicy kZonePolicyZion;
 //---------------------------------------------------------------------------
 
 // Belize {LETTER 'CST' not single character}
-// Eire {SAVE '-1:00' different from 1:00}
+// Eire {SAVE '-1:00' is a negative DST}
 // LH {SAVE '0:30' different from 1:00}
-// Moncton {AT '0:01' not on 15-minute boundary}
-// Morocco {SAVE '-1:00' different from 1:00}
+// Moncton {AT '0:01' not multiple of :15 min}
+// Morocco {SAVE '-1:00' is a negative DST}
 // Namibia {
 //   LETTER 'CAT' not single character,
 //   LETTER 'WAT' not single character,
-//   SAVE '-1:00' different from 1:00,
+//   SAVE '-1:00' is a negative DST,
 // }
-// Palestine {AT '0:01' not on 15-minute boundary}
+// Palestine {AT '0:01' not multiple of :15 min}
 // StJohns {
-//   AT '0:01' not on 15-minute boundary,
+//   AT '0:01' not multiple of :15 min,
 //   LETTER 'DD' not single character,
 //   SAVE '2:00' different from 1:00,
 // }

--- a/src/zonedbx/zone_registry.cpp
+++ b/src/zonedbx/zone_registry.cpp
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -23,7 +23,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -37,10 +37,10 @@
 //   Infos: 596
 //   Eras: 646
 //   Policies: 83
-//   Rules: 737
+//   Rules: 735
 //
 // Memory (8-bits):
-//   Rules: 8107
+//   Rules: 8085
 //   Policies: 249
 //   Eras: 7752
 //   Zones: 4550
@@ -50,10 +50,10 @@
 //   Letters: 46
 //   Fragments: 150
 //   Names: 5649 (original: 9076)
-//   TOTAL: 31490
+//   TOTAL: 31468
 //
 // Memory (32-bits):
-//   Rules: 8844
+//   Rules: 8820
 //   Policies: 664
 //   Eras: 10336
 //   Zones: 8400
@@ -63,7 +63,7 @@
 //   Letters: 64
 //   Fragments: 178
 //   Names: 5649 (original: 9076)
-//   TOTAL: 43020
+//   TOTAL: 42996
 //
 // DO NOT EDIT
 

--- a/src/zonedbx/zone_registry.h
+++ b/src/zonedbx/zone_registry.h
@@ -3,7 +3,7 @@
 //   $ /home/brian/src/AceTimeTools/src/acetimetools/tzcompiler.py
 //     --input_dir /home/brian/src/AceTime/src/zonedbx/tzfiles
 //     --output_dir /home/brian/src/AceTime/src/zonedbx
-//     --tz_version 2023b
+//     --tz_version 2023c
 //     --action zonedb
 //     --language arduino
 //     --scope extended
@@ -23,7 +23,7 @@
 //   northamerica
 //   southamerica
 //
-// from https://github.com/eggert/tz/releases/tag/2023b
+// from https://github.com/eggert/tz/releases/tag/2023c
 //
 // Supported Zones: 596 (350 zones, 246 links)
 // Unsupported Zones: 0 (0 zones, 0 links)
@@ -37,10 +37,10 @@
 //   Infos: 596
 //   Eras: 646
 //   Policies: 83
-//   Rules: 737
+//   Rules: 735
 //
 // Memory (8-bits):
-//   Rules: 8107
+//   Rules: 8085
 //   Policies: 249
 //   Eras: 7752
 //   Zones: 4550
@@ -50,10 +50,10 @@
 //   Letters: 46
 //   Fragments: 150
 //   Names: 5649 (original: 9076)
-//   TOTAL: 31490
+//   TOTAL: 31468
 //
 // Memory (32-bits):
-//   Rules: 8844
+//   Rules: 8820
 //   Policies: 664
 //   Eras: 10336
 //   Zones: 8400
@@ -63,7 +63,7 @@
 //   Letters: 64
 //   Fragments: 178
 //   Names: 5649 (original: 9076)
-//   TOTAL: 43020
+//   TOTAL: 42996
 //
 // DO NOT EDIT
 


### PR DESCRIPTION
* 2.2.2 (2023-04-01, TZDB version 2023c)
    * Upgrade TZDB from 2023b to 2023c.
        * https://mm.icann.org/pipermail/tz-announce/2023-March/000079.html
            * "This release's code and data are identical to 2023a.  In other
              words, this release reverts all changes made in 2023b other than
              commentary, as that appears to be the best of a bad set of
              short-notice choices for modeling this week's daylight saving
              chaos in Lebanon."
    * AceTime is forced to upgrade to 2023c, because we skipped 2023a and went
      directly to 2023b, which is being rolled back by 2023c.
